### PR TITLE
fix(products): harden filter parsing and keep catalog cards at standard size on large screens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -274,6 +274,10 @@ p {
   grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
 }
 
+.product-grid-catalog {
+  margin-top: 1rem;
+}
+
 .seller-grid {
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
 }
@@ -449,6 +453,13 @@ p {
 
   .details-grid {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (min-width: 1024px) {
+  .product-grid-catalog {
+    grid-template-columns: repeat(auto-fill, minmax(230px, 280px));
+    justify-content: start;
   }
 }
 

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -15,8 +15,16 @@ export default async function ProductsPage({ searchParams }: ProductsPageProps) 
   const params = await searchParams;
   const query = params.q?.trim().toLowerCase() ?? "";
   const category = params.category ?? "All";
-  const min = Number(params.min ?? "0");
-  const max = Number(params.max ?? "999999");
+  const min =
+    params.min && params.min.trim() !== "" && !Number.isNaN(Number(params.min))
+      ? Number(params.min)
+      : 0;
+  const max =
+    params.max && params.max.trim() !== "" && !Number.isNaN(Number(params.max))
+      ? Number(params.max)
+      : Number.POSITIVE_INFINITY;
+  const [normalizedMin, normalizedMax] =
+    min <= max ? [min, max] : [max, min];
   const sort = params.sort ?? "featured";
 
   const filtered = products
@@ -26,7 +34,8 @@ export default async function ProductsPage({ searchParams }: ProductsPageProps) 
         product.title.toLowerCase().includes(query) ||
         product.description.toLowerCase().includes(query);
       const matchesCategory = category === "All" || product.category === category;
-      const matchesPrice = product.price >= min && product.price <= max;
+      const matchesPrice =
+        product.price >= normalizedMin && product.price <= normalizedMax;
 
       return matchesQuery && matchesCategory && matchesPrice;
     })
@@ -110,7 +119,7 @@ export default async function ProductsPage({ searchParams }: ProductsPageProps) 
       </form>
 
       <p aria-live="polite">{filtered.length} product(s) found</p>
-      <div className="product-grid" style={{ marginTop: "1rem" }}>
+      <div className="product-grid product-grid-catalog">
         {filtered.map((product) => (
           <ProductCard key={product.id} product={product} />
         ))}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -9,7 +9,7 @@ const links = [
   { href: "/products", label: "Products" },
   { href: "/sellers", label: "Sellers" },
   { href: "/reviews", label: "Reviews" },
-  { href: "/about", label: "Community" },
+  { href: "/about", label: "About Us" },
 ];
 
 export function SiteHeader() {


### PR DESCRIPTION
handle empty/invalid min and max query params safely normalize inverted price ranges to avoid empty results add catalog-specific grid rules so product cards do not stretch on wide layouts replace inline grid spacing style with a CSS class update header nav label from "Community" to "About Us"